### PR TITLE
Fix merging of common and function argument headers

### DIFF
--- a/examples/basic_schema/single/simpleAPI.ts
+++ b/examples/basic_schema/single/simpleAPI.ts
@@ -24,6 +24,8 @@ export class SimpleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/basic_schema/split/simpleAPI.ts
+++ b/examples/basic_schema/split/simpleAPI.ts
@@ -21,6 +21,8 @@ export class SimpleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/basic_schema/tags/default.ts
+++ b/examples/basic_schema/tags/default.ts
@@ -21,6 +21,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/form_data_schema/single/formDataAPI.ts
+++ b/examples/form_data_schema/single/formDataAPI.ts
@@ -39,6 +39,8 @@ export class FormDataAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -67,8 +69,8 @@ export class FormDataAPIClient {
     const response = http.request('POST', url.toString(), formData.body(), {
       ...mergedRequestParameters,
       headers: {
-        'Content-Type': 'multipart/form-data; boundary=' + formData.boundary,
         ...mergedRequestParameters?.headers,
+        'Content-Type': 'multipart/form-data; boundary=' + formData.boundary,
       },
     })
     let data

--- a/examples/form_data_schema/split/formDataAPI.ts
+++ b/examples/form_data_schema/split/formDataAPI.ts
@@ -22,6 +22,8 @@ export class FormDataAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -50,8 +52,8 @@ export class FormDataAPIClient {
     const response = http.request('POST', url.toString(), formData.body(), {
       ...mergedRequestParameters,
       headers: {
-        'Content-Type': 'multipart/form-data; boundary=' + formData.boundary,
         ...mergedRequestParameters?.headers,
+        'Content-Type': 'multipart/form-data; boundary=' + formData.boundary,
       },
     })
     let data

--- a/examples/form_data_schema/tags/default.ts
+++ b/examples/form_data_schema/tags/default.ts
@@ -22,6 +22,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -50,8 +52,8 @@ export class DefaultClient {
     const response = http.request('POST', url.toString(), formData.body(), {
       ...mergedRequestParameters,
       headers: {
-        'Content-Type': 'multipart/form-data; boundary=' + formData.boundary,
         ...mergedRequestParameters?.headers,
+        'Content-Type': 'multipart/form-data; boundary=' + formData.boundary,
       },
     })
     let data

--- a/examples/form_url_encoded_data_schema/single/formURLEncodedAPI.ts
+++ b/examples/form_url_encoded_data_schema/single/formURLEncodedAPI.ts
@@ -38,6 +38,8 @@ export class FormURLEncodedAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -63,8 +65,8 @@ export class FormURLEncodedAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     )

--- a/examples/form_url_encoded_data_schema/split/formURLEncodedAPI.ts
+++ b/examples/form_url_encoded_data_schema/split/formURLEncodedAPI.ts
@@ -24,6 +24,8 @@ export class FormURLEncodedAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -49,8 +51,8 @@ export class FormURLEncodedAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     )

--- a/examples/form_url_encoded_data_schema/tags/default.ts
+++ b/examples/form_url_encoded_data_schema/tags/default.ts
@@ -24,6 +24,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -49,8 +51,8 @@ export class DefaultClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     )

--- a/examples/form_url_encoded_data_with_query_params_schema/single/formURLEncodedAPIWithQueryParameters.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/single/formURLEncodedAPIWithQueryParameters.ts
@@ -49,6 +49,8 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -79,8 +81,8 @@ export class FormURLEncodedAPIWithQueryParametersClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     )

--- a/examples/form_url_encoded_data_with_query_params_schema/split/formURLEncodedAPIWithQueryParameters.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/split/formURLEncodedAPIWithQueryParameters.ts
@@ -25,6 +25,8 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -55,8 +57,8 @@ export class FormURLEncodedAPIWithQueryParametersClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     )

--- a/examples/form_url_encoded_data_with_query_params_schema/tags/default.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/tags/default.ts
@@ -25,6 +25,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -55,8 +57,8 @@ export class DefaultClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     )

--- a/examples/get_request_with_path_parameters_schema/single/simpleAPI.ts
+++ b/examples/get_request_with_path_parameters_schema/single/simpleAPI.ts
@@ -26,6 +26,8 @@ export class SimpleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/get_request_with_path_parameters_schema/split/simpleAPI.ts
+++ b/examples/get_request_with_path_parameters_schema/split/simpleAPI.ts
@@ -22,6 +22,8 @@ export class SimpleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/get_request_with_path_parameters_schema/tags/default.ts
+++ b/examples/get_request_with_path_parameters_schema/tags/default.ts
@@ -22,6 +22,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/headers_schema/single/headerDemoAPI.ts
+++ b/examples/headers_schema/single/headerDemoAPI.ts
@@ -46,6 +46,8 @@ export class HeaderDemoAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -67,6 +69,7 @@ export class HeaderDemoAPIClient {
     const response = http.request('GET', url.toString(), undefined, {
       ...mergedRequestParameters,
       headers: {
+        ...mergedRequestParameters?.headers,
         // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
         ...Object.fromEntries(
           Object.entries(headers || {}).map(([key, value]) => [
@@ -74,7 +77,6 @@ export class HeaderDemoAPIClient {
             String(value),
           ])
         ),
-        ...mergedRequestParameters?.headers,
       },
     })
     let data
@@ -114,6 +116,7 @@ export class HeaderDemoAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
+          ...mergedRequestParameters?.headers,
           'Content-Type': 'application/json',
           // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
           ...Object.fromEntries(
@@ -122,7 +125,6 @@ export class HeaderDemoAPIClient {
               String(value),
             ])
           ),
-          ...mergedRequestParameters?.headers,
         },
       }
     )

--- a/examples/headers_schema/split/headerDemoAPI.ts
+++ b/examples/headers_schema/split/headerDemoAPI.ts
@@ -28,6 +28,8 @@ export class HeaderDemoAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -49,6 +51,7 @@ export class HeaderDemoAPIClient {
     const response = http.request('GET', url.toString(), undefined, {
       ...mergedRequestParameters,
       headers: {
+        ...mergedRequestParameters?.headers,
         // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
         ...Object.fromEntries(
           Object.entries(headers || {}).map(([key, value]) => [
@@ -56,7 +59,6 @@ export class HeaderDemoAPIClient {
             String(value),
           ])
         ),
-        ...mergedRequestParameters?.headers,
       },
     })
     let data
@@ -96,6 +98,7 @@ export class HeaderDemoAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
+          ...mergedRequestParameters?.headers,
           'Content-Type': 'application/json',
           // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
           ...Object.fromEntries(
@@ -104,7 +107,6 @@ export class HeaderDemoAPIClient {
               String(value),
             ])
           ),
-          ...mergedRequestParameters?.headers,
         },
       }
     )

--- a/examples/headers_schema/tags/default.ts
+++ b/examples/headers_schema/tags/default.ts
@@ -28,6 +28,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -49,6 +51,7 @@ export class DefaultClient {
     const response = http.request('GET', url.toString(), undefined, {
       ...mergedRequestParameters,
       headers: {
+        ...mergedRequestParameters?.headers,
         // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
         ...Object.fromEntries(
           Object.entries(headers || {}).map(([key, value]) => [
@@ -56,7 +59,6 @@ export class DefaultClient {
             String(value),
           ])
         ),
-        ...mergedRequestParameters?.headers,
       },
     })
     let data
@@ -95,6 +97,7 @@ export class DefaultClient {
       {
         ...mergedRequestParameters,
         headers: {
+          ...mergedRequestParameters?.headers,
           'Content-Type': 'application/json',
           // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string
           ...Object.fromEntries(
@@ -103,7 +106,6 @@ export class DefaultClient {
               String(value),
             ])
           ),
-          ...mergedRequestParameters?.headers,
         },
       }
     )

--- a/examples/no_title_schema/single/k6Client.ts
+++ b/examples/no_title_schema/single/k6Client.ts
@@ -23,6 +23,8 @@ export class K6ClientClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/no_title_schema/split/k6Client.ts
+++ b/examples/no_title_schema/split/k6Client.ts
@@ -21,6 +21,8 @@ export class K6ClientClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/no_title_schema/tags/default.ts
+++ b/examples/no_title_schema/tags/default.ts
@@ -21,6 +21,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/post_request_with_query_params/single/exampleAPI.ts
+++ b/examples/post_request_with_query_params/single/exampleAPI.ts
@@ -47,6 +47,8 @@ export class ExampleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -77,8 +79,8 @@ export class ExampleAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/json',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/json',
         },
       }
     )

--- a/examples/post_request_with_query_params/split/exampleAPI.ts
+++ b/examples/post_request_with_query_params/split/exampleAPI.ts
@@ -26,6 +26,8 @@ export class ExampleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -56,8 +58,8 @@ export class ExampleAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/json',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/json',
         },
       }
     )

--- a/examples/post_request_with_query_params/tags/default.ts
+++ b/examples/post_request_with_query_params/tags/default.ts
@@ -26,6 +26,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -56,8 +58,8 @@ export class DefaultClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/json',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/json',
         },
       }
     )

--- a/examples/query_params_schema/single/exampleAPI.ts
+++ b/examples/query_params_schema/single/exampleAPI.ts
@@ -51,6 +51,8 @@ export class ExampleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/query_params_schema/split/exampleAPI.ts
+++ b/examples/query_params_schema/split/exampleAPI.ts
@@ -25,6 +25,8 @@ export class ExampleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/query_params_schema/tags/default.ts
+++ b/examples/query_params_schema/tags/default.ts
@@ -25,6 +25,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**

--- a/examples/simple_post_request_schema/single/exampleAPI.ts
+++ b/examples/simple_post_request_schema/single/exampleAPI.ts
@@ -61,6 +61,8 @@ export class ExampleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -86,8 +88,8 @@ export class ExampleAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/json',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/json',
         },
       }
     )

--- a/examples/simple_post_request_schema/split/exampleAPI.ts
+++ b/examples/simple_post_request_schema/split/exampleAPI.ts
@@ -25,6 +25,8 @@ export class ExampleAPIClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -50,8 +52,8 @@ export class ExampleAPIClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/json',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/json',
         },
       }
     )

--- a/examples/simple_post_request_schema/tags/default.ts
+++ b/examples/simple_post_request_schema/tags/default.ts
@@ -25,6 +25,8 @@ export class DefaultClient {
     commonRequestParameters?: Params
   }) {
     this.cleanBaseUrl = clientOptions.baseUrl.replace(/\/+$/, '')
+
+    this.commonRequestParameters = clientOptions.commonRequestParameters || {}
   }
 
   /**
@@ -50,8 +52,8 @@ export class DefaultClient {
       {
         ...mergedRequestParameters,
         headers: {
-          'Content-Type': 'application/json',
           ...mergedRequestParameters?.headers,
+          'Content-Type': 'application/json',
         },
       }
     )

--- a/src/generator/k6Client.ts
+++ b/src/generator/k6Client.ts
@@ -55,22 +55,23 @@ function _getRequestParametersMergerFunctionImplementation() {
  * Merges the provided request parameters with default parameters for the client.
  *
  * @param {Params} requestParameters - The parameters provided specifically for the request
+ * @param {Params} commonRequestParameters - Common parameters for all requests
  * @returns {Params} - The merged parameters
  */
-  private _mergeRequestParameters (requestParameters?: Params): Params {
+  private _mergeRequestParameters (requestParameters?: Params, commonRequestParameters?: Params): Params {
     return {
-        ...this.commonRequestParameters,  // Default to common parameters
+        ...commonRequestParameters,  // Default to common parameters
         ...requestParameters,        // Override with request-specific parameters
         headers: {
-            ...this.commonRequestParameters?.headers || {},  // Ensure headers are defined
+            ...commonRequestParameters?.headers || {},  // Ensure headers are defined
             ...requestParameters?.headers || {},
         },
         cookies: {
-            ...this.commonRequestParameters?.cookies || {},  // Ensure cookies are defined
+            ...commonRequestParameters?.cookies || {},  // Ensure cookies are defined
             ...requestParameters?.cookies || {},
         },
         tags: {
-            ...this.commonRequestParameters?.tags || {},     // Ensure tags are defined
+            ...commonRequestParameters?.tags || {},     // Ensure tags are defined
             ...requestParameters?.tags || {},
         },
     };
@@ -234,7 +235,7 @@ const generateK6Implementation = (
 
   return `${operationName}(\n    ${toObjectString(props, 'implementation')} requestParameters?: Params): ${_generateResponseTypeDefinition(response)} {\n${bodyForm}
         ${urlGeneration}
-        const mergedRequestParameters = this._mergeRequestParameters(requestParameters || {});
+        const mergedRequestParameters = this._mergeRequestParameters(requestParameters || {}, this.commonRequestParameters);
         const response = http.request(${options});
         let data;
 

--- a/tests/functional-tests/test-generator/fixtures/form_data_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/form_data_schema.json
@@ -88,7 +88,7 @@
       "export class FormDataAPIClient",
       "const formData = new FormData(); formData.append(\"file\", postUploadBody.file); if (postUploadBody.description !== undefined) { formData.append(\"description\", postUploadBody.description); } formData.append(\"userId\", postUploadBody.userId);",
       "const url = new URL(this.cleanBaseUrl + `/upload`);",
-      "const response = http.request(\"POST\", url.toString(), formData.body(), { ...mergedRequestParameters, headers: { \"Content-Type\": \"multipart/form-data; boundary=\" + formData.boundary, ...mergedRequestParameters?.headers, }, });"
+      "const response = http.request(\"POST\", url.toString(), formData.body(), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"multipart/form-data; boundary=\" + formData.boundary, }, });"
     ]
   }
 }

--- a/tests/functional-tests/test-generator/fixtures/form_url_encoded_data_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/form_url_encoded_data_schema.json
@@ -87,7 +87,7 @@
     "expectedSubstrings": [
       "export class FormURLEncodedAPIClient",
       "const url = new URL(this.cleanBaseUrl + `/submit-form`);",
-      "const response = http.request( \"POST\", url.toString(), JSON.stringify(postSubmitFormBody), { ...mergedRequestParameters, headers: { \"Content-Type\": \"application/x-www-form-urlencoded\", ...mergedRequestParameters?.headers, }, }, );"
+      "const response = http.request( \"POST\", url.toString(), JSON.stringify(postSubmitFormBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/x-www-form-urlencoded\", }, }, );"
     ]
   }
 }

--- a/tests/functional-tests/test-generator/fixtures/headers_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/headers_schema.json
@@ -152,9 +152,9 @@
     "expectedSubstrings": [
       "export class HeaderDemoAPIClient",
       "getExampleGet( headers?: GetExampleGetHeaders, requestParameters?: Params, ): { response: Response; data: GetExampleGet200; }",
-      "response = http.request(\"GET\", url.toString(), undefined, { ...mergedRequestParameters, headers: { // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), ...mergedRequestParameters?.headers, }, });",
+      "response = http.request(\"GET\", url.toString(), undefined, { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, });",
       "postExamplePost( postExamplePostBody: PostExamplePostBody, headers: PostExamplePostHeaders, requestParameters?: Params, ): { response: Response; data: void; }",
-      "response = http.request( \"POST\", url.toString(), JSON.stringify(postExamplePostBody), { ...mergedRequestParameters, headers: { \"Content-Type\": \"application/json\", // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), ...mergedRequestParameters?.headers, }, }, );",
+      "response = http.request( \"POST\", url.toString(), JSON.stringify(postExamplePostBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/json\", // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, }, );",
       "getExampleResponseHeaders(requestParameters?: Params): { response: Response; data: GetExampleResponseHeaders200; }",
       "response = http.request( \"GET\", url.toString(), undefined, mergedRequestParameters, );"
     ]


### PR DESCRIPTION
- Give precedence to the value of the header sent as function arguments over the common headers set for the client
- Fix the missing initialization for common request headers 
- Add E2E tests to validate that the correct header value is used. 