### PR TITLE
fix: rename url token to k6url to avoid duplication

### DIFF
--- a/examples/basic_schema/single/simpleAPI.ts
+++ b/examples/basic_schema/single/simpleAPI.ts
@@ -35,14 +35,14 @@ export class SimpleAPIClient {
     response: Response
     data: GetExample200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/basic_schema/split/simpleAPI.ts
+++ b/examples/basic_schema/split/simpleAPI.ts
@@ -32,14 +32,14 @@ export class SimpleAPIClient {
     response: Response
     data: GetExample200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/basic_schema/tags/default.ts
+++ b/examples/basic_schema/tags/default.ts
@@ -32,14 +32,14 @@ export class DefaultClient {
     response: Response
     data: GetExample200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/form_data_schema/single/formDataAPI.ts
+++ b/examples/form_data_schema/single/formDataAPI.ts
@@ -61,12 +61,12 @@ export class FormDataAPIClient {
     }
     formData.append('userId', postUploadBody.userId)
 
-    const url = new URL(this.cleanBaseUrl + `/upload`)
+    const k6url = new URL(this.cleanBaseUrl + `/upload`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('POST', url.toString(), formData.body(), {
+    const response = http.request('POST', k6url.toString(), formData.body(), {
       ...mergedRequestParameters,
       headers: {
         ...mergedRequestParameters?.headers,

--- a/examples/form_data_schema/split/formDataAPI.ts
+++ b/examples/form_data_schema/split/formDataAPI.ts
@@ -44,12 +44,12 @@ export class FormDataAPIClient {
     }
     formData.append('userId', postUploadBody.userId)
 
-    const url = new URL(this.cleanBaseUrl + `/upload`)
+    const k6url = new URL(this.cleanBaseUrl + `/upload`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('POST', url.toString(), formData.body(), {
+    const response = http.request('POST', k6url.toString(), formData.body(), {
       ...mergedRequestParameters,
       headers: {
         ...mergedRequestParameters?.headers,

--- a/examples/form_data_schema/tags/default.ts
+++ b/examples/form_data_schema/tags/default.ts
@@ -44,12 +44,12 @@ export class DefaultClient {
     }
     formData.append('userId', postUploadBody.userId)
 
-    const url = new URL(this.cleanBaseUrl + `/upload`)
+    const k6url = new URL(this.cleanBaseUrl + `/upload`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('POST', url.toString(), formData.body(), {
+    const response = http.request('POST', k6url.toString(), formData.body(), {
       ...mergedRequestParameters,
       headers: {
         ...mergedRequestParameters?.headers,

--- a/examples/form_url_encoded_data_schema/single/formURLEncodedAPI.ts
+++ b/examples/form_url_encoded_data_schema/single/formURLEncodedAPI.ts
@@ -53,14 +53,14 @@ export class FormURLEncodedAPIClient {
     response: Response
     data: PostSubmitForm200
   } {
-    const url = new URL(this.cleanBaseUrl + `/submit-form`)
+    const k6url = new URL(this.cleanBaseUrl + `/submit-form`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postSubmitFormBody),
       {
         ...mergedRequestParameters,

--- a/examples/form_url_encoded_data_schema/split/formURLEncodedAPI.ts
+++ b/examples/form_url_encoded_data_schema/split/formURLEncodedAPI.ts
@@ -39,14 +39,14 @@ export class FormURLEncodedAPIClient {
     response: Response
     data: PostSubmitForm200
   } {
-    const url = new URL(this.cleanBaseUrl + `/submit-form`)
+    const k6url = new URL(this.cleanBaseUrl + `/submit-form`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postSubmitFormBody),
       {
         ...mergedRequestParameters,

--- a/examples/form_url_encoded_data_schema/tags/default.ts
+++ b/examples/form_url_encoded_data_schema/tags/default.ts
@@ -39,14 +39,14 @@ export class DefaultClient {
     response: Response
     data: PostSubmitForm200
   } {
-    const url = new URL(this.cleanBaseUrl + `/submit-form`)
+    const k6url = new URL(this.cleanBaseUrl + `/submit-form`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postSubmitFormBody),
       {
         ...mergedRequestParameters,

--- a/examples/form_url_encoded_data_with_query_params_schema/single/formURLEncodedAPIWithQueryParameters.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/single/formURLEncodedAPIWithQueryParameters.ts
@@ -65,7 +65,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     response: Response
     data: PostSubmitForm200
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/submit-form` +
         `?${new URLSearchParams(params).toString()}`
@@ -76,7 +76,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postSubmitFormBody),
       {
         ...mergedRequestParameters,

--- a/examples/form_url_encoded_data_with_query_params_schema/split/formURLEncodedAPIWithQueryParameters.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/split/formURLEncodedAPIWithQueryParameters.ts
@@ -41,7 +41,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     response: Response
     data: PostSubmitForm200
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/submit-form` +
         `?${new URLSearchParams(params).toString()}`
@@ -52,7 +52,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postSubmitFormBody),
       {
         ...mergedRequestParameters,

--- a/examples/form_url_encoded_data_with_query_params_schema/tags/default.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/tags/default.ts
@@ -41,7 +41,7 @@ export class DefaultClient {
     response: Response
     data: PostSubmitForm200
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/submit-form` +
         `?${new URLSearchParams(params).toString()}`
@@ -52,7 +52,7 @@ export class DefaultClient {
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postSubmitFormBody),
       {
         ...mergedRequestParameters,

--- a/examples/get_request_with_path_parameters_schema/single/simpleAPI.ts
+++ b/examples/get_request_with_path_parameters_schema/single/simpleAPI.ts
@@ -41,14 +41,14 @@ export class SimpleAPIClient {
     response: Response
     data: GetItemById200
   } {
-    const url = new URL(this.cleanBaseUrl + `/items/${id}`)
+    const k6url = new URL(this.cleanBaseUrl + `/items/${id}`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/get_request_with_path_parameters_schema/split/simpleAPI.ts
+++ b/examples/get_request_with_path_parameters_schema/split/simpleAPI.ts
@@ -37,14 +37,14 @@ export class SimpleAPIClient {
     response: Response
     data: GetItemById200
   } {
-    const url = new URL(this.cleanBaseUrl + `/items/${id}`)
+    const k6url = new URL(this.cleanBaseUrl + `/items/${id}`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/get_request_with_path_parameters_schema/tags/default.ts
+++ b/examples/get_request_with_path_parameters_schema/tags/default.ts
@@ -37,14 +37,14 @@ export class DefaultClient {
     response: Response
     data: GetItemById200
   } {
-    const url = new URL(this.cleanBaseUrl + `/items/${id}`)
+    const k6url = new URL(this.cleanBaseUrl + `/items/${id}`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/headers_schema/single/headerDemoAPI.ts
+++ b/examples/headers_schema/single/headerDemoAPI.ts
@@ -61,12 +61,12 @@ export class HeaderDemoAPIClient {
     response: Response
     data: GetExampleGet200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-get`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-get`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('GET', url.toString(), undefined, {
+    const response = http.request('GET', k6url.toString(), undefined, {
       ...mergedRequestParameters,
       headers: {
         ...mergedRequestParameters?.headers,
@@ -104,14 +104,14 @@ export class HeaderDemoAPIClient {
     response: Response
     data: void
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-post`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-post`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postExamplePostBody),
       {
         ...mergedRequestParameters,
@@ -149,14 +149,14 @@ export class HeaderDemoAPIClient {
     response: Response
     data: GetExampleResponseHeaders200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-response-headers`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-response-headers`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/headers_schema/split/headerDemoAPI.ts
+++ b/examples/headers_schema/split/headerDemoAPI.ts
@@ -43,12 +43,12 @@ export class HeaderDemoAPIClient {
     response: Response
     data: GetExampleGet200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-get`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-get`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('GET', url.toString(), undefined, {
+    const response = http.request('GET', k6url.toString(), undefined, {
       ...mergedRequestParameters,
       headers: {
         ...mergedRequestParameters?.headers,
@@ -86,14 +86,14 @@ export class HeaderDemoAPIClient {
     response: Response
     data: void
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-post`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-post`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postExamplePostBody),
       {
         ...mergedRequestParameters,
@@ -131,14 +131,14 @@ export class HeaderDemoAPIClient {
     response: Response
     data: GetExampleResponseHeaders200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-response-headers`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-response-headers`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/headers_schema/tags/default.ts
+++ b/examples/headers_schema/tags/default.ts
@@ -43,12 +43,12 @@ export class DefaultClient {
     response: Response
     data: GetExampleGet200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-get`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-get`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('GET', url.toString(), undefined, {
+    const response = http.request('GET', k6url.toString(), undefined, {
       ...mergedRequestParameters,
       headers: {
         ...mergedRequestParameters?.headers,
@@ -85,14 +85,14 @@ export class DefaultClient {
     response: Response
     data: void
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-post`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-post`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(postExamplePostBody),
       {
         ...mergedRequestParameters,
@@ -129,14 +129,14 @@ export class DefaultClient {
     response: Response
     data: GetExampleResponseHeaders200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example-response-headers`)
+    const k6url = new URL(this.cleanBaseUrl + `/example-response-headers`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/no_title_schema/single/k6Client.ts
+++ b/examples/no_title_schema/single/k6Client.ts
@@ -34,14 +34,14 @@ export class K6ClientClient {
     response: Response
     data: GetExample200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/no_title_schema/split/k6Client.ts
+++ b/examples/no_title_schema/split/k6Client.ts
@@ -32,14 +32,14 @@ export class K6ClientClient {
     response: Response
     data: GetExample200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/no_title_schema/tags/default.ts
+++ b/examples/no_title_schema/tags/default.ts
@@ -32,14 +32,14 @@ export class DefaultClient {
     response: Response
     data: GetExample200
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'GET',
-      url.toString(),
+      k6url.toString(),
       undefined,
       mergedRequestParameters
     )

--- a/examples/post_request_with_query_params/single/exampleAPI.ts
+++ b/examples/post_request_with_query_params/single/exampleAPI.ts
@@ -63,7 +63,7 @@ export class ExampleAPIClient {
     response: Response
     data: CreateExampleData201
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/example` +
         `?${new URLSearchParams(params).toString()}`
@@ -74,7 +74,7 @@ export class ExampleAPIClient {
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(createExampleDataBody),
       {
         ...mergedRequestParameters,

--- a/examples/post_request_with_query_params/split/exampleAPI.ts
+++ b/examples/post_request_with_query_params/split/exampleAPI.ts
@@ -42,7 +42,7 @@ export class ExampleAPIClient {
     response: Response
     data: CreateExampleData201
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/example` +
         `?${new URLSearchParams(params).toString()}`
@@ -53,7 +53,7 @@ export class ExampleAPIClient {
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(createExampleDataBody),
       {
         ...mergedRequestParameters,

--- a/examples/post_request_with_query_params/tags/default.ts
+++ b/examples/post_request_with_query_params/tags/default.ts
@@ -42,7 +42,7 @@ export class DefaultClient {
     response: Response
     data: CreateExampleData201
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/example` +
         `?${new URLSearchParams(params).toString()}`
@@ -53,7 +53,7 @@ export class DefaultClient {
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(createExampleDataBody),
       {
         ...mergedRequestParameters,

--- a/examples/query_params_schema/single/exampleAPI.ts
+++ b/examples/query_params_schema/single/exampleAPI.ts
@@ -66,7 +66,7 @@ export class ExampleAPIClient {
     response: Response
     data: GetExampleData200
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/example` +
         `?${new URLSearchParams(params).toString()}`
@@ -75,7 +75,7 @@ export class ExampleAPIClient {
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('GET', url.toString(), undefined, {
+    const response = http.request('GET', k6url.toString(), undefined, {
       ...mergedRequestParameters,
     })
     let data

--- a/examples/query_params_schema/split/exampleAPI.ts
+++ b/examples/query_params_schema/split/exampleAPI.ts
@@ -40,7 +40,7 @@ export class ExampleAPIClient {
     response: Response
     data: GetExampleData200
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/example` +
         `?${new URLSearchParams(params).toString()}`
@@ -49,7 +49,7 @@ export class ExampleAPIClient {
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('GET', url.toString(), undefined, {
+    const response = http.request('GET', k6url.toString(), undefined, {
       ...mergedRequestParameters,
     })
     let data

--- a/examples/query_params_schema/tags/default.ts
+++ b/examples/query_params_schema/tags/default.ts
@@ -40,7 +40,7 @@ export class DefaultClient {
     response: Response
     data: GetExampleData200
   } {
-    const url = new URL(
+    const k6url = new URL(
       this.cleanBaseUrl +
         `/example` +
         `?${new URLSearchParams(params).toString()}`
@@ -49,7 +49,7 @@ export class DefaultClient {
       requestParameters || {},
       this.commonRequestParameters
     )
-    const response = http.request('GET', url.toString(), undefined, {
+    const response = http.request('GET', k6url.toString(), undefined, {
       ...mergedRequestParameters,
     })
     let data

--- a/examples/simple_post_request_schema/single/exampleAPI.ts
+++ b/examples/simple_post_request_schema/single/exampleAPI.ts
@@ -76,14 +76,14 @@ export class ExampleAPIClient {
     response: Response
     data: CreateExampleData201
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(createExampleDataBody),
       {
         ...mergedRequestParameters,

--- a/examples/simple_post_request_schema/split/exampleAPI.ts
+++ b/examples/simple_post_request_schema/split/exampleAPI.ts
@@ -40,14 +40,14 @@ export class ExampleAPIClient {
     response: Response
     data: CreateExampleData201
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(createExampleDataBody),
       {
         ...mergedRequestParameters,

--- a/examples/simple_post_request_schema/tags/default.ts
+++ b/examples/simple_post_request_schema/tags/default.ts
@@ -40,14 +40,14 @@ export class DefaultClient {
     response: Response
     data: CreateExampleData201
   } {
-    const url = new URL(this.cleanBaseUrl + `/example`)
+    const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
       requestParameters || {},
       this.commonRequestParameters
     )
     const response = http.request(
       'POST',
-      url.toString(),
+      k6url.toString(),
       JSON.stringify(createExampleDataBody),
       {
         ...mergedRequestParameters,

--- a/src/generator/k6Client.ts
+++ b/src/generator/k6Client.ts
@@ -50,6 +50,8 @@ function _generateResponseTypeDefinition(response: GetterResponse): string {
 }`
 }
 
+const INTERNAL_URL_TOKEN = 'k6url'
+
 function _getRequestParametersMergerFunctionImplementation() {
   return `/**
  * Merges the provided request parameters with default parameters for the client.
@@ -147,7 +149,7 @@ const _getK6RequestOptions = (verbOptions: GeneratorVerbOptions) => {
   // 'GET', 'http://test.com/route', <body>, <options>
 
   return `"${verb.toUpperCase()}",
-        url.toString(),
+        ${INTERNAL_URL_TOKEN}.toString(),
         ${fetchBodyOption},
         ${requestParametersValue}`
 }
@@ -229,7 +231,7 @@ const generateK6Implementation = (
   if (queryParams) {
     url += '+`?${new URLSearchParams(params).toString()}`'
   }
-  const urlGeneration = `const url = new URL(${url});`
+  const urlGeneration = `const ${INTERNAL_URL_TOKEN} = new URL(${url});`
 
   const options = _getK6RequestOptions(verbOptions)
 

--- a/tests/functional-tests/test-generator/fixtures/form_data_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/form_data_schema.json
@@ -87,8 +87,8 @@
     "expectedSubstrings": [
       "export class FormDataAPIClient",
       "const formData = new FormData(); formData.append(\"file\", postUploadBody.file); if (postUploadBody.description !== undefined) { formData.append(\"description\", postUploadBody.description); } formData.append(\"userId\", postUploadBody.userId);",
-      "const url = new URL(this.cleanBaseUrl + `/upload`);",
-      "const response = http.request(\"POST\", url.toString(), formData.body(), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"multipart/form-data; boundary=\" + formData.boundary, }, });"
+      "const k6url = new URL(this.cleanBaseUrl + `/upload`);",
+      "const response = http.request(\"POST\", k6url.toString(), formData.body(), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"multipart/form-data; boundary=\" + formData.boundary, }, });"
     ]
   }
 }

--- a/tests/functional-tests/test-generator/fixtures/form_url_encoded_data_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/form_url_encoded_data_schema.json
@@ -86,8 +86,8 @@
     "fileName": "formURLEncodedAPI.ts",
     "expectedSubstrings": [
       "export class FormURLEncodedAPIClient",
-      "const url = new URL(this.cleanBaseUrl + `/submit-form`);",
-      "const response = http.request( \"POST\", url.toString(), JSON.stringify(postSubmitFormBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/x-www-form-urlencoded\", }, }, );"
+      "const k6url = new URL(this.cleanBaseUrl + `/submit-form`);",
+      "const response = http.request( \"POST\", k6url.toString(), JSON.stringify(postSubmitFormBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/x-www-form-urlencoded\", }, }, );"
     ]
   }
 }

--- a/tests/functional-tests/test-generator/fixtures/get_request_with_path_parameters_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/get_request_with_path_parameters_schema.json
@@ -60,7 +60,7 @@
     "fileName": "simpleAPI.ts",
     "expectedSubstrings": [
       "getItemById( id: string, requestParameters?: Params, ): ",
-      "const url = new URL(this.cleanBaseUrl + `/items/${id}`);"
+      "const k6url = new URL(this.cleanBaseUrl + `/items/${id}`);"
     ]
   }
 }

--- a/tests/functional-tests/test-generator/fixtures/headers_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/headers_schema.json
@@ -152,11 +152,11 @@
     "expectedSubstrings": [
       "export class HeaderDemoAPIClient",
       "getExampleGet( headers?: GetExampleGetHeaders, requestParameters?: Params, ): { response: Response; data: GetExampleGet200; }",
-      "response = http.request(\"GET\", url.toString(), undefined, { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, });",
+      "response = http.request(\"GET\", k6url.toString(), undefined, { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, });",
       "postExamplePost( postExamplePostBody: PostExamplePostBody, headers: PostExamplePostHeaders, requestParameters?: Params, ): { response: Response; data: void; }",
-      "response = http.request( \"POST\", url.toString(), JSON.stringify(postExamplePostBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/json\", // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, }, );",
+      "response = http.request( \"POST\", k6url.toString(), JSON.stringify(postExamplePostBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/json\", // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, }, );",
       "getExampleResponseHeaders(requestParameters?: Params): { response: Response; data: GetExampleResponseHeaders200; }",
-      "response = http.request( \"GET\", url.toString(), undefined, mergedRequestParameters, );"
+      "response = http.request( \"GET\", k6url.toString(), undefined, mergedRequestParameters, );"
     ]
   }
 }

--- a/tests/functional-tests/test-generator/fixtures/simple_post_request_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/simple_post_request_schema.json
@@ -121,7 +121,7 @@
     "fileName": "exampleAPI.ts",
     "expectedSubstrings": [
       "export class ExampleAPIClient {",
-      "const url = new URL(this.cleanBaseUrl + `/example`);",
+      "const k6url = new URL(this.cleanBaseUrl + `/example`);",
       "JSON.stringify(createExampleDataBody),",
       "POST",
       "export type CreateExampleData201 = { /** The unique ID of the created resource */ id?: string; name?: string; age?: number; isActive?: boolean; tags?: string[]; date?: string; meta?: CreateExampleData201Meta; };"


### PR DESCRIPTION
I've renamed the `url` variable in the generated code to `k6url` to avoid mismatches in the generation code leading to invalid code

fixes #53 