### PR TITLE
feat(generator): Add operationId to result object returned from operation methods

### DIFF
--- a/examples/basic_schema/single/simpleAPI.ts
+++ b/examples/basic_schema/single/simpleAPI.ts
@@ -34,6 +34,7 @@ export class SimpleAPIClient {
   getExample(requestParameters?: Params): {
     response: Response
     data: GetExample200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -56,6 +57,7 @@ export class SimpleAPIClient {
     return {
       response,
       data,
+      operationId: 'GetExample',
     }
   }
 

--- a/examples/basic_schema/split/simpleAPI.ts
+++ b/examples/basic_schema/split/simpleAPI.ts
@@ -31,6 +31,7 @@ export class SimpleAPIClient {
   getExample(requestParameters?: Params): {
     response: Response
     data: GetExample200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -53,6 +54,7 @@ export class SimpleAPIClient {
     return {
       response,
       data,
+      operationId: 'GetExample',
     }
   }
 

--- a/examples/basic_schema/tags/default.ts
+++ b/examples/basic_schema/tags/default.ts
@@ -31,6 +31,7 @@ export class DefaultClient {
   getExample(requestParameters?: Params): {
     response: Response
     data: GetExample200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -53,6 +54,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'GetExample',
     }
   }
 

--- a/examples/form_data_schema/single/formDataAPI.ts
+++ b/examples/form_data_schema/single/formDataAPI.ts
@@ -53,6 +53,7 @@ export class FormDataAPIClient {
   ): {
     response: Response
     data: PostUpload200
+    operationId: string
   } {
     const formData = new FormData()
     formData.append('file', postUploadBody.file)
@@ -83,6 +84,7 @@ export class FormDataAPIClient {
     return {
       response,
       data,
+      operationId: 'PostUpload',
     }
   }
 

--- a/examples/form_data_schema/split/formDataAPI.ts
+++ b/examples/form_data_schema/split/formDataAPI.ts
@@ -36,6 +36,7 @@ export class FormDataAPIClient {
   ): {
     response: Response
     data: PostUpload200
+    operationId: string
   } {
     const formData = new FormData()
     formData.append('file', postUploadBody.file)
@@ -66,6 +67,7 @@ export class FormDataAPIClient {
     return {
       response,
       data,
+      operationId: 'PostUpload',
     }
   }
 

--- a/examples/form_data_schema/tags/default.ts
+++ b/examples/form_data_schema/tags/default.ts
@@ -36,6 +36,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: PostUpload200
+    operationId: string
   } {
     const formData = new FormData()
     formData.append('file', postUploadBody.file)
@@ -66,6 +67,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'PostUpload',
     }
   }
 

--- a/examples/form_url_encoded_data_schema/single/formURLEncodedAPI.ts
+++ b/examples/form_url_encoded_data_schema/single/formURLEncodedAPI.ts
@@ -52,6 +52,7 @@ export class FormURLEncodedAPIClient {
   ): {
     response: Response
     data: PostSubmitForm200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/submit-form`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -80,6 +81,7 @@ export class FormURLEncodedAPIClient {
     return {
       response,
       data,
+      operationId: 'PostSubmitForm',
     }
   }
 

--- a/examples/form_url_encoded_data_schema/split/formURLEncodedAPI.ts
+++ b/examples/form_url_encoded_data_schema/split/formURLEncodedAPI.ts
@@ -38,6 +38,7 @@ export class FormURLEncodedAPIClient {
   ): {
     response: Response
     data: PostSubmitForm200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/submit-form`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -66,6 +67,7 @@ export class FormURLEncodedAPIClient {
     return {
       response,
       data,
+      operationId: 'PostSubmitForm',
     }
   }
 

--- a/examples/form_url_encoded_data_schema/tags/default.ts
+++ b/examples/form_url_encoded_data_schema/tags/default.ts
@@ -38,6 +38,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: PostSubmitForm200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/submit-form`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -66,6 +67,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'PostSubmitForm',
     }
   }
 

--- a/examples/form_url_encoded_data_with_query_params_schema/single/formURLEncodedAPIWithQueryParameters.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/single/formURLEncodedAPIWithQueryParameters.ts
@@ -64,6 +64,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
   ): {
     response: Response
     data: PostSubmitForm200
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -96,6 +97,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     return {
       response,
       data,
+      operationId: 'PostSubmitForm',
     }
   }
 

--- a/examples/form_url_encoded_data_with_query_params_schema/split/formURLEncodedAPIWithQueryParameters.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/split/formURLEncodedAPIWithQueryParameters.ts
@@ -40,6 +40,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
   ): {
     response: Response
     data: PostSubmitForm200
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -72,6 +73,7 @@ export class FormURLEncodedAPIWithQueryParametersClient {
     return {
       response,
       data,
+      operationId: 'PostSubmitForm',
     }
   }
 

--- a/examples/form_url_encoded_data_with_query_params_schema/tags/default.ts
+++ b/examples/form_url_encoded_data_with_query_params_schema/tags/default.ts
@@ -40,6 +40,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: PostSubmitForm200
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -72,6 +73,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'PostSubmitForm',
     }
   }
 

--- a/examples/get_request_with_path_parameters_schema/single/simpleAPI.ts
+++ b/examples/get_request_with_path_parameters_schema/single/simpleAPI.ts
@@ -40,6 +40,7 @@ export class SimpleAPIClient {
   ): {
     response: Response
     data: GetItemById200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/items/${id}`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -62,6 +63,7 @@ export class SimpleAPIClient {
     return {
       response,
       data,
+      operationId: 'getItemById',
     }
   }
 

--- a/examples/get_request_with_path_parameters_schema/split/simpleAPI.ts
+++ b/examples/get_request_with_path_parameters_schema/split/simpleAPI.ts
@@ -36,6 +36,7 @@ export class SimpleAPIClient {
   ): {
     response: Response
     data: GetItemById200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/items/${id}`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -58,6 +59,7 @@ export class SimpleAPIClient {
     return {
       response,
       data,
+      operationId: 'getItemById',
     }
   }
 

--- a/examples/get_request_with_path_parameters_schema/tags/default.ts
+++ b/examples/get_request_with_path_parameters_schema/tags/default.ts
@@ -36,6 +36,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: GetItemById200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/items/${id}`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -58,6 +59,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'getItemById',
     }
   }
 

--- a/examples/headers_schema/single/headerDemoAPI.ts
+++ b/examples/headers_schema/single/headerDemoAPI.ts
@@ -60,6 +60,7 @@ export class HeaderDemoAPIClient {
   ): {
     response: Response
     data: GetExampleGet200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-get`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -89,6 +90,7 @@ export class HeaderDemoAPIClient {
     return {
       response,
       data,
+      operationId: 'GetExampleGet',
     }
   }
 
@@ -103,6 +105,7 @@ export class HeaderDemoAPIClient {
   ): {
     response: Response
     data: void
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-post`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -138,6 +141,7 @@ export class HeaderDemoAPIClient {
     return {
       response,
       data,
+      operationId: 'PostExamplePost',
     }
   }
 
@@ -148,6 +152,7 @@ export class HeaderDemoAPIClient {
   getExampleResponseHeaders(requestParameters?: Params): {
     response: Response
     data: GetExampleResponseHeaders200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-response-headers`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -170,6 +175,7 @@ export class HeaderDemoAPIClient {
     return {
       response,
       data,
+      operationId: 'GetExampleResponseHeaders',
     }
   }
 

--- a/examples/headers_schema/split/headerDemoAPI.ts
+++ b/examples/headers_schema/split/headerDemoAPI.ts
@@ -42,6 +42,7 @@ export class HeaderDemoAPIClient {
   ): {
     response: Response
     data: GetExampleGet200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-get`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -71,6 +72,7 @@ export class HeaderDemoAPIClient {
     return {
       response,
       data,
+      operationId: 'GetExampleGet',
     }
   }
 
@@ -85,6 +87,7 @@ export class HeaderDemoAPIClient {
   ): {
     response: Response
     data: void
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-post`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -120,6 +123,7 @@ export class HeaderDemoAPIClient {
     return {
       response,
       data,
+      operationId: 'PostExamplePost',
     }
   }
 
@@ -130,6 +134,7 @@ export class HeaderDemoAPIClient {
   getExampleResponseHeaders(requestParameters?: Params): {
     response: Response
     data: GetExampleResponseHeaders200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-response-headers`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -152,6 +157,7 @@ export class HeaderDemoAPIClient {
     return {
       response,
       data,
+      operationId: 'GetExampleResponseHeaders',
     }
   }
 

--- a/examples/headers_schema/tags/default.ts
+++ b/examples/headers_schema/tags/default.ts
@@ -42,6 +42,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: GetExampleGet200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-get`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -71,6 +72,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'GetExampleGet',
     }
   }
   /**
@@ -84,6 +86,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: void
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-post`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -119,6 +122,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'PostExamplePost',
     }
   }
   /**
@@ -128,6 +132,7 @@ export class DefaultClient {
   getExampleResponseHeaders(requestParameters?: Params): {
     response: Response
     data: GetExampleResponseHeaders200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example-response-headers`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -150,6 +155,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'GetExampleResponseHeaders',
     }
   }
 

--- a/examples/no_title_schema/single/k6Client.ts
+++ b/examples/no_title_schema/single/k6Client.ts
@@ -33,6 +33,7 @@ export class K6ClientClient {
   getExample(requestParameters?: Params): {
     response: Response
     data: GetExample200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -55,6 +56,7 @@ export class K6ClientClient {
     return {
       response,
       data,
+      operationId: 'GetExample',
     }
   }
 

--- a/examples/no_title_schema/split/k6Client.ts
+++ b/examples/no_title_schema/split/k6Client.ts
@@ -31,6 +31,7 @@ export class K6ClientClient {
   getExample(requestParameters?: Params): {
     response: Response
     data: GetExample200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -53,6 +54,7 @@ export class K6ClientClient {
     return {
       response,
       data,
+      operationId: 'GetExample',
     }
   }
 

--- a/examples/no_title_schema/tags/default.ts
+++ b/examples/no_title_schema/tags/default.ts
@@ -31,6 +31,7 @@ export class DefaultClient {
   getExample(requestParameters?: Params): {
     response: Response
     data: GetExample200
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -53,6 +54,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'GetExample',
     }
   }
 

--- a/examples/post_request_with_query_params/single/exampleAPI.ts
+++ b/examples/post_request_with_query_params/single/exampleAPI.ts
@@ -62,6 +62,7 @@ export class ExampleAPIClient {
   ): {
     response: Response
     data: CreateExampleData201
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -94,6 +95,7 @@ export class ExampleAPIClient {
     return {
       response,
       data,
+      operationId: 'createExampleData',
     }
   }
 

--- a/examples/post_request_with_query_params/split/exampleAPI.ts
+++ b/examples/post_request_with_query_params/split/exampleAPI.ts
@@ -41,6 +41,7 @@ export class ExampleAPIClient {
   ): {
     response: Response
     data: CreateExampleData201
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -73,6 +74,7 @@ export class ExampleAPIClient {
     return {
       response,
       data,
+      operationId: 'createExampleData',
     }
   }
 

--- a/examples/post_request_with_query_params/tags/default.ts
+++ b/examples/post_request_with_query_params/tags/default.ts
@@ -41,6 +41,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: CreateExampleData201
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -73,6 +74,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'createExampleData',
     }
   }
 

--- a/examples/query_params_schema/single/exampleAPI.ts
+++ b/examples/query_params_schema/single/exampleAPI.ts
@@ -65,6 +65,7 @@ export class ExampleAPIClient {
   ): {
     response: Response
     data: GetExampleData200
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -88,6 +89,7 @@ export class ExampleAPIClient {
     return {
       response,
       data,
+      operationId: 'getExampleData',
     }
   }
 

--- a/examples/query_params_schema/split/exampleAPI.ts
+++ b/examples/query_params_schema/split/exampleAPI.ts
@@ -39,6 +39,7 @@ export class ExampleAPIClient {
   ): {
     response: Response
     data: GetExampleData200
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -62,6 +63,7 @@ export class ExampleAPIClient {
     return {
       response,
       data,
+      operationId: 'getExampleData',
     }
   }
 

--- a/examples/query_params_schema/tags/default.ts
+++ b/examples/query_params_schema/tags/default.ts
@@ -39,6 +39,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: GetExampleData200
+    operationId: string
   } {
     const k6url = new URL(
       this.cleanBaseUrl +
@@ -62,6 +63,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'getExampleData',
     }
   }
 

--- a/examples/simple_post_request_schema/single/exampleAPI.ts
+++ b/examples/simple_post_request_schema/single/exampleAPI.ts
@@ -75,6 +75,7 @@ export class ExampleAPIClient {
   ): {
     response: Response
     data: CreateExampleData201
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -103,6 +104,7 @@ export class ExampleAPIClient {
     return {
       response,
       data,
+      operationId: 'createExampleData',
     }
   }
 

--- a/examples/simple_post_request_schema/split/exampleAPI.ts
+++ b/examples/simple_post_request_schema/split/exampleAPI.ts
@@ -39,6 +39,7 @@ export class ExampleAPIClient {
   ): {
     response: Response
     data: CreateExampleData201
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -67,6 +68,7 @@ export class ExampleAPIClient {
     return {
       response,
       data,
+      operationId: 'createExampleData',
     }
   }
 

--- a/examples/simple_post_request_schema/tags/default.ts
+++ b/examples/simple_post_request_schema/tags/default.ts
@@ -39,6 +39,7 @@ export class DefaultClient {
   ): {
     response: Response
     data: CreateExampleData201
+    operationId: string
   } {
     const k6url = new URL(this.cleanBaseUrl + `/example`)
     const mergedRequestParameters = this._mergeRequestParameters(
@@ -67,6 +68,7 @@ export class DefaultClient {
     return {
       response,
       data,
+      operationId: 'createExampleData',
     }
   }
 

--- a/src/generator/k6Client.ts
+++ b/src/generator/k6Client.ts
@@ -15,11 +15,11 @@ import {
   pascal,
   sanitize,
   toObjectString,
+  jsStringEscape,
 } from '@orval/core'
 import { DEFAULT_SCHEMA_TITLE } from '../constants'
 import { AnalyticsData } from '../type'
 import { k6ScriptBuilder } from './k6ScriptBuilder'
-import { jsStringEscape } from 'orval'
 /**
  * In case the supplied schema does not have a title set, it will set the default title to ensure
  * proper client generation

--- a/src/generator/k6Client.ts
+++ b/src/generator/k6Client.ts
@@ -19,6 +19,7 @@ import {
 import { DEFAULT_SCHEMA_TITLE } from '../constants'
 import { AnalyticsData } from '../type'
 import { k6ScriptBuilder } from './k6ScriptBuilder'
+import { jsStringEscape } from 'orval'
 /**
  * In case the supplied schema does not have a title set, it will set the default title to ensure
  * proper client generation
@@ -47,6 +48,7 @@ function _generateResponseTypeDefinition(response: GetterResponse): string {
   return `{
     response: Response
     data: ${responseDataType}
+    operationId: string
 }`
 }
 
@@ -207,6 +209,7 @@ const generateK6Implementation = (
   const {
     queryParams,
     operationName,
+    operationId,
     response,
     body,
     props,
@@ -248,7 +251,8 @@ const generateK6Implementation = (
         }
       return {
         response,
-        data
+        data,
+        operationId: '${jsStringEscape(operationId)}'
       }
     }
   `

--- a/tests/functional-tests/test-generator/fixtures/form_url_encoded_data_with_query_params_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/form_url_encoded_data_with_query_params_schema.json
@@ -106,7 +106,7 @@
   "expected_sdk": {
     "fileName": "formURLEncodedAPIWithQueryParameters.ts",
     "expectedSubstrings": [
-      "postSubmitForm( postSubmitFormBody: PostSubmitFormBody, params: PostSubmitFormParams, requestParameters?: Params, ): { response: Response; data: PostSubmitForm200; }",
+      "postSubmitForm( postSubmitFormBody: PostSubmitFormBody, params: PostSubmitFormParams, requestParameters?: Params, ): { response: Response; data: PostSubmitForm200; operationId: string; }",
       "new URL( this.cleanBaseUrl + `/submit-form` + `?${new URLSearchParams(params).toString()}`, );"
     ]
   }

--- a/tests/functional-tests/test-generator/fixtures/headers_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/headers_schema.json
@@ -151,11 +151,11 @@
     "fileName": "headerDemoAPI.ts",
     "expectedSubstrings": [
       "export class HeaderDemoAPIClient",
-      "getExampleGet( headers?: GetExampleGetHeaders, requestParameters?: Params, ): { response: Response; data: GetExampleGet200; }",
+      "getExampleGet( headers?: GetExampleGetHeaders, requestParameters?: Params, ): { response: Response; data: GetExampleGet200; operationId: string; }",
       "response = http.request(\"GET\", k6url.toString(), undefined, { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, });",
-      "postExamplePost( postExamplePostBody: PostExamplePostBody, headers: PostExamplePostHeaders, requestParameters?: Params, ): { response: Response; data: void; }",
+      "postExamplePost( postExamplePostBody: PostExamplePostBody, headers: PostExamplePostHeaders, requestParameters?: Params, ): { response: Response; data: void; operationId: string; }",
       "response = http.request( \"POST\", k6url.toString(), JSON.stringify(postExamplePostBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/json\", // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, }, );",
-      "getExampleResponseHeaders(requestParameters?: Params): { response: Response; data: GetExampleResponseHeaders200; }",
+      "getExampleResponseHeaders(requestParameters?: Params): { response: Response; data: GetExampleResponseHeaders200; operationId: string; }",
       "response = http.request( \"GET\", k6url.toString(), undefined, mergedRequestParameters, );"
     ]
   }

--- a/tests/functional-tests/test-generator/generator.test.ts
+++ b/tests/functional-tests/test-generator/generator.test.ts
@@ -28,7 +28,10 @@ const commonSubstringsForAllSDK = [
   'Service version',
   'const mergedRequestParameters = this._mergeRequestParameters( requestParameters || {}, this.commonRequestParameters, );',
   'try { data = response.json(); } catch { data = response.body; }',
-  'return { response, data, };',
+]
+
+const commonMatchesForAllSDK = [
+  /return { response, data, operationId: "[^"]*", };/,
 ]
 
 const commonSubstringsForK6SampleScript = [`const baseUrl = "<BASE_URL>";`]
@@ -94,6 +97,11 @@ describe('generator', () => {
           expect(
             replaceSpacesAndNewLineToSingleSpace(generatedContent)
           ).toContain(expectedString)
+        }
+        for (const expectedToMatch of commonMatchesForAllSDK) {
+          expect(
+            replaceSpacesAndNewLineToSingleSpace(generatedContent)
+          ).toMatch(expectedToMatch)
         }
       })
 


### PR DESCRIPTION
Adds an `operationId` field to result objects returned by each generated operation method. This is useful for simplifying the lookup of spec details about a completed client operation. In my particular use case this is useful for simplifying validation of a response's data shape against an operation's response schema as defined within the openapi spec.