### PR TITLE
fix(security): pin @asyncapi/specs to 6.11.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6 # zizmor: ignore[cache-poisoning] npm caching is disabled here, so no runtime artifacts are cached
         with:
           node-version: '21'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,8 +27,6 @@ jobs:
           node-version: '21'
           registry-url: 'https://registry.npmjs.org'
           scope: '@grafana'
-          cache: 'npm'
-          cache-dependency-path: 'package-lock.json'
       - run: npm ci
       - name: Validate version matches release tag
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,11 +22,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6 # zizmor: ignore[cache-poisoning] npm caching is disabled here, so no runtime artifacts are cached
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version: '21'
           registry-url: 'https://registry.npmjs.org'
           scope: '@grafana'
+          package-manager-cache: false
       - run: npm ci
       - name: Validate version matches release tag
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,9 +89,10 @@
       }
     },
     "node_modules/@asyncapi/specs": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.8.1.tgz",
-      "integrity": "sha512-czHoAk3PeXTLR+X8IUaD+IpT+g+zUvkcgMDJVothBsan+oHN3jfcFcFUNdOPAAFoUCQN1hXF1dWuphWy05THlA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.11.1.tgz",
+      "integrity": "sha512-A3WBLqAKGoJ2+6FWFtpjBlCQ1oFCcs4GxF7zsIGvNqp/klGUHjlA3aAcZ9XMMpLGE8zPeYDz2x9FmO6DSuKraQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "vite-tsconfig-paths": "6.0.4",
     "vitest": "4.0.17"
   },
+  "overrides": {
+    "@asyncapi/specs": "6.11.1"
+  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix",


### PR DESCRIPTION
Pins the transitive dependency `@asyncapi/specs` to `6.11.1` via npm `overrides`.

This is necessary until npmjs has removed the compromised `6.11.2` (and `-alpha.1`) versions from their index, to prevent accidental installation outside of renovate.
