### PR TITLE
feat: add opt-in request preparation and batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ The following are some of the configuration options supported by the tool:
 
 3. `--disable-analytics`: Disable anonymous usage analytics reporting. You can also set an environment variable `DISABLE_ANALYTICS=true` to disable analytics.
 4. `--include-sample-script`: Generate a sample k6 script. The generated sample script uses the examples defined in the OpenAPI schema requests to make the script usable out of the box. If the examples are not defined, it will use Faker to generate random data.
-5. `--verbose` or `-v` : Enable verbose logging to see more detailed logging output.
-6. `--help` or `-h` : Show help message.
+5. `--include-prepared-requests`: Generate `prepare<Operation>()` methods and a typed `batch()` helper for collecting requests before executing them with `http.batch`. Existing operation methods remain available and execute requests immediately.
+6. `--verbose` or `-v` : Enable verbose logging to see more detailed logging output.
+7. `--help` or `-h` : Show help message.
 
 ## Developing locally
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ async function generateSDK({
   openApiPath,
   outputDir,
   shouldGenerateSampleK6Script,
+  shouldGeneratePreparedRequests,
   analyticsData,
   mode,
   tags,
@@ -54,6 +55,7 @@ async function generateSDK({
     openApiPath,
     outputDir,
     shouldGenerateSampleK6Script,
+    shouldGeneratePreparedRequests,
     analyticsData,
     mode,
     tags,
@@ -83,6 +85,10 @@ program
   )
   .option('-v, --verbose', 'enable verbose mode to show debug logs')
   .option('--include-sample-script', 'generate a sample k6 script')
+  .option(
+    '--include-prepared-requests',
+    'generate helpers for preparing and batching requests'
+  )
   .option('--disable-analytics', 'disable anonymous usage data collection')
   .action(
     async (
@@ -94,6 +100,7 @@ program
         onlyTags?: (string | RegExp)[]
         disableAnalytics?: boolean
         includeSampleScript?: boolean
+        includePreparedRequests?: boolean
       }
     ) => {
       let analyticsData: AnalyticsData | undefined
@@ -124,6 +131,7 @@ program
           openApiPath,
           outputDir,
           shouldGenerateSampleK6Script: !!options.includeSampleScript,
+          shouldGeneratePreparedRequests: !!options.includePreparedRequests,
           analyticsData,
           mode: options.mode,
           tags: options.onlyTags,

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -115,6 +115,7 @@ export default async ({
   openApiPath,
   outputDir,
   shouldGenerateSampleK6Script,
+  shouldGeneratePreparedRequests,
   analyticsData,
   mode,
   tags,
@@ -135,7 +136,11 @@ export default async ({
         target: outputDir,
         mode: mode,
         client: () =>
-          getK6ClientBuilder(shouldGenerateSampleK6Script, analyticsData),
+          getK6ClientBuilder(
+            shouldGenerateSampleK6Script,
+            analyticsData,
+            shouldGeneratePreparedRequests
+          ),
         override: {
           header: generatedFileHeaderGenerator,
         },

--- a/src/generator/k6Client.ts
+++ b/src/generator/k6Client.ts
@@ -34,6 +34,20 @@ function _setDefaultSchemaTitle(context: ContextSpecs) {
 }
 
 function _generateResponseTypeDefinition(response: GetterResponse): string {
+  return `{
+    response: Response
+    data: ${_getResponseDataType(response)}
+    operationId: string
+}`
+}
+
+function _generatePreparedRequestTypeDefinition(
+  response: GetterResponse
+): string {
+  return `PreparedRequest<${_getResponseDataType(response)}>`
+}
+
+function _getResponseDataType(response: GetterResponse): string {
   let responseDataType = ''
 
   if (
@@ -45,11 +59,20 @@ function _generateResponseTypeDefinition(response: GetterResponse): string {
     responseDataType += 'ResponseBody'
   }
 
-  return `{
-    response: Response
-    data: ${responseDataType}
-    operationId: string
-}`
+  return responseDataType
+}
+
+function _generateResponseParser(response: GetterResponse): string {
+  const responseDataType = _getResponseDataType(response)
+  if (responseDataType === 'void') return '() => undefined'
+
+  return `(response) => {
+            try {
+              return response.json() as unknown as ${responseDataType};
+            } catch {
+              return response.body as unknown as ${responseDataType};
+            }
+          }`
 }
 
 const INTERNAL_URL_TOKEN = 'k6url'
@@ -127,14 +150,17 @@ const _getRequestParamsValue = ({
   return `{${value}}`
 }
 
-const _getK6RequestOptions = (verbOptions: GeneratorVerbOptions) => {
+const _getK6RequestParts = (verbOptions: GeneratorVerbOptions) => {
   const { body, headers, queryParams, response, verb } = verbOptions
   let fetchBodyOption = 'undefined'
 
   if (body.formData) {
     // Use the FormData.body() method to get the body of the request
     fetchBodyOption = 'formData.body()'
-  } else if (body.contentType === 'application/json') {
+  } else if (
+    body.contentType === 'application/json' ||
+    body.contentType?.endsWith('+json')
+  ) {
     fetchBodyOption = `JSON.stringify(${body.implementation})`
   } else if (body.formUrlEncoded) {
     fetchBodyOption = `\n// k6 accepts JS objects for form URL encoded requests, but all properties must be strings`
@@ -152,64 +178,87 @@ const _getK6RequestOptions = (verbOptions: GeneratorVerbOptions) => {
     queryParams: queryParams?.schema,
   })
 
-  // Sample output
-  // 'GET', 'http://test.com/route', <body>, <options>
-
-  return `"${verb.toUpperCase()}",
-        ${INTERNAL_URL_TOKEN}.toString(),
-        ${fetchBodyOption},
-        ${requestParametersValue}`
+  return {
+    method: `"${verb.toUpperCase()}"`,
+    url: `${INTERNAL_URL_TOKEN}.toString()`,
+    body: fetchBodyOption,
+    params: requestParametersValue,
+  }
 }
 
-const getK6Dependencies: ClientDependenciesBuilder = () => [
-  {
-    exports: [
-      {
-        name: 'http',
-        default: true,
-        values: true,
-        syntheticDefaultImport: true,
-      },
-      { name: 'Response' },
-      { name: 'ResponseBody' },
-      { name: 'Params' },
-    ],
-    dependency: 'k6/http',
-  },
-  {
-    exports: [
-      {
-        name: 'URLSearchParams',
-        default: false,
-        values: true,
-        // syntheticDefaultImport: true,
-      },
-      {
-        name: 'URL',
-        default: false,
-        values: true,
-        // syntheticDefaultImport: true,
-      },
-    ],
-    dependency: 'https://jslib.k6.io/url/1.0.0/index.js',
-  },
-  {
-    exports: [
-      {
-        name: 'FormData',
-        default: false,
-        values: true,
-        // syntheticDefaultImport: true,
-      },
-    ],
-    dependency: 'https://jslib.k6.io/formdata/0.0.2/index.js',
-  },
-]
+const _getK6RequestOptions = (verbOptions: GeneratorVerbOptions) => {
+  const { method, url, body, params } = _getK6RequestParts(verbOptions)
+  return `${method},
+        ${url},
+        ${body},
+        ${params}`
+}
+
+const _getK6BatchRequest = (verbOptions: GeneratorVerbOptions) => {
+  const { method, url, body, params } = _getK6RequestParts(verbOptions)
+  return `{
+        method: ${method},
+        url: ${url},
+        body: ${body},
+        params: ${params},
+      }`
+}
+
+const getK6Dependencies =
+  (shouldGeneratePreparedRequests: boolean): ClientDependenciesBuilder =>
+  () => [
+    {
+      exports: [
+        {
+          name: 'http',
+          default: true,
+          values: true,
+          syntheticDefaultImport: true,
+        },
+        { name: 'Response' },
+        { name: 'ResponseBody' },
+        { name: 'Params' },
+        ...(shouldGeneratePreparedRequests
+          ? [{ name: 'ObjectBatchRequest' }]
+          : []),
+      ],
+      dependency: 'k6/http',
+    },
+    {
+      exports: [
+        {
+          name: 'URLSearchParams',
+          default: false,
+          values: true,
+          // syntheticDefaultImport: true,
+        },
+        {
+          name: 'URL',
+          default: false,
+          values: true,
+          // syntheticDefaultImport: true,
+        },
+      ],
+      dependency: 'https://jslib.k6.io/url/1.0.0/index.js',
+    },
+    {
+      exports: [
+        {
+          name: 'FormData',
+          default: false,
+          values: true,
+          // syntheticDefaultImport: true,
+        },
+      ],
+      dependency: 'https://jslib.k6.io/formdata/0.0.2/index.js',
+    },
+  ]
 
 const generateK6Implementation = (
   verbOptions: GeneratorVerbOptions,
   { route }: GeneratorOptions,
-  analyticsData?: AnalyticsData
+  analyticsData?: AnalyticsData,
+  shouldGeneratePreparedRequests = false
 ) => {
   const {
     queryParams,
@@ -241,9 +290,10 @@ const generateK6Implementation = (
   }
   const urlGeneration = `const ${INTERNAL_URL_TOKEN} = new URL(${url});`
 
-  const options = _getK6RequestOptions(verbOptions)
+  if (!shouldGeneratePreparedRequests) {
+    const options = _getK6RequestOptions(verbOptions)
 
-  return `${operationName}(\n    ${toObjectString(props, 'implementation')} requestParameters?: Params): ${_generateResponseTypeDefinition(response)} {\n${bodyForm}
+    return `${operationName}(\n    ${toObjectString(props, 'implementation')} requestParameters?: Params): ${_generateResponseTypeDefinition(response)} {\n${bodyForm}
         ${urlGeneration}
         const mergedRequestParameters = this._mergeRequestParameters(requestParameters || {}, this.commonRequestParameters);
         const response = http.request(${options});
@@ -261,6 +311,30 @@ const generateK6Implementation = (
       }
     }
   `
+  }
+
+  const request = _getK6BatchRequest(verbOptions)
+  const preparedRequestType = _generatePreparedRequestTypeDefinition(response)
+  const responseType = `OperationResult<${_getResponseDataType(response)}>`
+  const prepareOperationName = `prepare${pascal(operationName)}`
+
+  return `${prepareOperationName}(\n    ${toObjectString(props, 'implementation')} requestParameters?: Params): ${preparedRequestType} {\n${bodyForm}
+        ${urlGeneration}
+        const mergedRequestParameters = this._mergeRequestParameters(requestParameters || {}, this.commonRequestParameters);
+        return {
+          request: ${request},
+          operationId: '${jsStringEscape(operationId)}',
+          parse: ${_generateResponseParser(response)},
+        };
+    }
+
+    ${operationName}(\n    ${toObjectString(props, 'implementation')} requestParameters?: Params): ${responseType} {
+      return this.execute(this.${prepareOperationName}(${props
+        .map(({ name }) => name)
+        .concat('requestParameters')
+        .join(', ')}));
+    }
+  `
 }
 
 export const generateTitle: ClientTitleBuilder = (title) => {
@@ -268,8 +342,33 @@ export const generateTitle: ClientTitleBuilder = (title) => {
   return `${pascal(sanTitle)}Client`
 }
 
-const generateK6Header: ClientHeaderBuilder = ({ title }) => {
-  return `
+const generateK6Header =
+  (shouldGeneratePreparedRequests: boolean): ClientHeaderBuilder =>
+  ({ title }) => {
+    return `
+  ${
+    shouldGeneratePreparedRequests
+      ? `export interface PreparedRequest<Data> {
+    request: ObjectBatchRequest;
+    operationId: string;
+    parse: (response: Response) => Data;
+  }
+
+  export interface OperationResult<Data> {
+    response: Response;
+    data: Data;
+    operationId: string;
+  }
+
+  export type PreparedRequestData<Request> =
+    Request extends PreparedRequest<infer Data> ? Data : never;
+
+  export type BatchResults<Requests extends readonly PreparedRequest<unknown>[]> = {
+    -readonly [Index in keyof Requests]: OperationResult<PreparedRequestData<Requests[Index]>>;
+  };`
+      : ''
+  }
+
   /**
    * This is the base client to use for interacting with the API.
    */
@@ -285,21 +384,59 @@ const generateK6Header: ClientHeaderBuilder = ({ title }) => {
        this.commonRequestParameters = clientOptions.commonRequestParameters || {};
       }\n
 `
-}
+  }
 
-const generateFooter: ClientFooterBuilder = () => {
-  // Add function definition for merging request parameters
-  const footer = `
+const generateFooter =
+  (shouldGeneratePreparedRequests: boolean): ClientFooterBuilder =>
+  () => {
+    // Add function definition for merging request parameters
+    const footer = `
+
+  ${
+    shouldGeneratePreparedRequests
+      ? `execute<Data>(preparedRequest: PreparedRequest<Data>): OperationResult<Data> {
+    const { method, url, body, params } = preparedRequest.request;
+    const response = http.request(method, url, body, params);
+    return this._resolvePreparedRequest(preparedRequest, response);
+  }
+
+  batch<const Requests extends readonly PreparedRequest<unknown>[]>(
+    preparedRequests: Requests,
+  ): BatchResults<Requests> {
+    const responses = http.batch(
+      preparedRequests.map(({ request }) => request),
+    );
+
+    return preparedRequests.map((preparedRequest, index) =>
+      this._resolvePreparedRequest(preparedRequest, responses[index]!),
+    ) as BatchResults<Requests>;
+  }
+
+  private _resolvePreparedRequest<Data>(
+    preparedRequest: PreparedRequest<Data>,
+    response: Response,
+  ): OperationResult<Data> {
+    return {
+      response,
+      data: preparedRequest.parse(response),
+      operationId: preparedRequest.operationId,
+    };
+  }`
+      : ''
+  }
 
   ${_getRequestParametersMergerFunctionImplementation()}
 
 }
 
   `
-  return footer
-}
+    return footer
+  }
 
-function getK6Client(analyticsData?: AnalyticsData) {
+function getK6Client(
+  analyticsData?: AnalyticsData,
+  shouldGeneratePreparedRequests = false
+) {
   return function (
     verbOptions: GeneratorVerbOptions,
     options: GeneratorOptions
@@ -310,7 +447,8 @@ function getK6Client(analyticsData?: AnalyticsData) {
     const implementation = generateK6Implementation(
       verbOptions,
       options,
-      analyticsData
+      analyticsData,
+      shouldGeneratePreparedRequests
     )
     const specData = Object.values(options.context.specs)
     if (specData[0]) {
@@ -325,13 +463,14 @@ function getK6Client(analyticsData?: AnalyticsData) {
 
 export function getK6ClientBuilder(
   shouldGenerateSampleK6Script?: boolean,
-  analyticsData?: AnalyticsData
+  analyticsData?: AnalyticsData,
+  shouldGeneratePreparedRequests?: boolean
 ): ClientGeneratorsBuilder {
   return {
-    client: getK6Client(analyticsData),
-    header: generateK6Header,
-    dependencies: getK6Dependencies,
-    footer: generateFooter,
+    client: getK6Client(analyticsData, shouldGeneratePreparedRequests),
+    header: generateK6Header(!!shouldGeneratePreparedRequests),
+    dependencies: getK6Dependencies(!!shouldGeneratePreparedRequests),
+    footer: generateFooter(!!shouldGeneratePreparedRequests),
     title: generateTitle,
     extraFiles: shouldGenerateSampleK6Script ? k6ScriptBuilder : undefined,
   }

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -29,6 +29,7 @@ export interface GenerateK6SDKOptions {
   openApiPath: string
   outputDir: string
   shouldGenerateSampleK6Script?: boolean
+  shouldGeneratePreparedRequests?: boolean
   analyticsData?: AnalyticsData
   mode: Mode
   tags?: (string | RegExp)[]

--- a/tests/functional-tests/test-generator/fixtures/headers_schema.json
+++ b/tests/functional-tests/test-generator/fixtures/headers_schema.json
@@ -70,7 +70,7 @@
             "description": "Request body",
             "required": true,
             "content": {
-              "application/json": {
+              "application/merge-patch+json": {
                 "schema": {
                   "type": "object",
                   "properties": {
@@ -154,7 +154,7 @@
       "getExampleGet( headers?: GetExampleGetHeaders, requestParameters?: Params, ): { response: Response; data: GetExampleGet200; operationId: string; }",
       "response = http.request(\"GET\", k6url.toString(), undefined, { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, });",
       "postExamplePost( postExamplePostBody: PostExamplePostBody, headers: PostExamplePostHeaders, requestParameters?: Params, ): { response: Response; data: void; operationId: string; }",
-      "response = http.request( \"POST\", k6url.toString(), JSON.stringify(postExamplePostBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/json\", // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, }, );",
+      "response = http.request( \"POST\", k6url.toString(), JSON.stringify(postExamplePostBody), { ...mergedRequestParameters, headers: { ...mergedRequestParameters?.headers, \"Content-Type\": \"application/merge-patch+json\", // In the schema, headers can be of any type like number but k6 accepts only strings as headers, hence converting all headers to string ...Object.fromEntries( Object.entries(headers || {}).map(([key, value]) => [ key, String(value), ]), ), }, }, );",
       "getExampleResponseHeaders(requestParameters?: Params): { response: Response; data: GetExampleResponseHeaders200; operationId: string; }",
       "response = http.request( \"GET\", k6url.toString(), undefined, mergedRequestParameters, );"
     ]

--- a/tests/functional-tests/test-generator/generator.test.ts
+++ b/tests/functional-tests/test-generator/generator.test.ts
@@ -153,10 +153,60 @@ describe('generator', () => {
 
         const generatedFilePath = path.join(generatedSchemaPath, clientFile!)
         const generatedContent = await readFile(generatedFilePath, 'utf-8')
-
         expect(generatedContent).not.toContain('export type')
         expect(generatedContent).not.toContain('export interface')
       })
     })
   }
+
+  describe('prepared requests', () => {
+    const fixture = loadFixture(
+      path.join(__dirname, 'fixtures', 'headers_schema.json')
+    )
+
+    async function generatePreparedRequestsFixture() {
+      const directory = await mkdtemp(path.join(tempDir, 'prepared-requests-'))
+      const openApiPath = path.join(directory, 'openapi-schema.json')
+      const outputDir = path.join(directory, 'generated-schema')
+      await writeFile(openApiPath, JSON.stringify(fixture['openapi_schema']))
+      await generator({
+        openApiPath,
+        outputDir,
+        mode: Mode.SINGLE,
+        shouldGeneratePreparedRequests: true,
+      })
+
+      const [generatedFile] = fs.readdirSync(outputDir)
+      const content = await readFile(
+        path.join(outputDir, generatedFile!),
+        'utf-8'
+      )
+      await rmdir(directory, { recursive: true })
+      return replaceSpacesAndNewLineToSingleSpace(content)
+    }
+
+    it('generates prepared requests and batch execution when enabled', async () => {
+      const generatedContent = await generatePreparedRequestsFixture()
+
+      expect(generatedContent).toContain(
+        'prepareGetExampleGet( headers?: GetExampleGetHeaders, requestParameters?: Params, ): PreparedRequest<GetExampleGet200>'
+      )
+      expect(generatedContent).toContain(
+        'return this.execute(this.prepareGetExampleGet(headers, requestParameters));'
+      )
+      expect(generatedContent).toContain(
+        'body: JSON.stringify(postExamplePostBody)'
+      )
+      expect(generatedContent).toContain(
+        'return response.json() as unknown as GetExampleGet200'
+      )
+      expect(generatedContent).toContain('parse: () => undefined')
+      expect(generatedContent).toContain(
+        'batch<const Requests extends readonly PreparedRequest<unknown>[]>( preparedRequests: Requests, ): BatchResults<Requests>'
+      )
+      expect(generatedContent).toContain(
+        'const responses = http.batch( preparedRequests.map(({ request }) => request), );'
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Context

This is an experimental design proposal rather than a thoroughly reviewed implementation. Our load-test workload models need to describe several API calls first and then execute them together with `http.batch()`. The current generated methods execute immediately, which makes that difficult without rebuilding request serialization outside the generated client.

Maintainers may prefer a different API or extension point; this draft is intended to make the use case and one possible implementation concrete, and individual ideas may be more useful than the patch as-is.

## Proposed shape

- Add opt-in `--include-prepared-requests`; default generated output stays unchanged.
- Generate `prepare<Operation>()` methods that serialize URL, query, body, headers, and params without I/O.
- Keep existing operation methods, delegating them through the prepared request path.
- Add typed `execute()` and `batch()` helpers. Mixed-operation tuple batches retain each response type by index.

```ts
const results = client.batch([
  client.prepareGetProject(projectId),
  client.prepareListInitiatives({ projectId }),
]);
```

## Validation

- Added a focused generator test for the opt-in prepared-request behavior. Existing generator fixtures continue to cover default generation without the option.
- Full test suite: 60 passing.
- Build and lint pass.
- Manually type-checked generated clients with mixed response types.

Feedback on whether request preparation belongs in this generator, and on the generated API naming, would be especially useful.